### PR TITLE
[Fix] 가끔 미래의 시간으로 변환되는 문제

### DIFF
--- a/Sources/Transcoding/VideoDecoderAnnexBAdaptor.swift
+++ b/Sources/Transcoding/VideoDecoderAnnexBAdaptor.swift
@@ -134,20 +134,15 @@ public final class VideoDecoderAnnexBAdaptor {
         }
     }
   
-    private func logDiff(senderHostTime: TimeInterval, senderPTS: TimeInterval, receiverHostTime: TimeInterval, receiverPTS: TimeInterval) {
-        let hostTimeDiff = receiverHostTime - senderHostTime
-        let ptsDiff = receiverPTS - senderPTS
+    private func logDiff(receiverHostTime: TimeInterval, receiverPTS: TimeInterval) {
         let latency = receiverHostTime - receiverPTS
         
         Self.logger.debug(
           """
-          [FrameLog] SenderHostTime: \(String(format: "%.3f", senderHostTime), privacy: .public), \n\
-          SenderPTS: \(String(format: "%.3f", senderPTS), privacy: .public), \n\
-          ReceiverHostTime (Mine): \(String(format: "%.3f", receiverHostTime), privacy: .public), \n\
-          ReceiverPTS (Mine): \(String(format: "%.3f", receiverPTS), privacy: .public), \n\
-          HostTimeDiff: \(String(format: "%.3f", hostTimeDiff), privacy: .public)s, \n\
-          PTSDiff: \(String(format: "%.3f", ptsDiff), privacy: .public)s, \n\
-          Latency: \(String(format: "%.3f", latency), privacy: .public)s,
+          [FrameLog] \n\
+          My HostTime: \(String(format: "%.3f", receiverHostTime), privacy: .public), \n\
+          My PTS: \(String(format: "%.3f", receiverPTS), privacy: .public), \n\
+          Latency (My HostTime - My PTS): \(String(format: "%.3f", latency), privacy: .public)s,
           """
         )
     }
@@ -160,7 +155,10 @@ public final class VideoDecoderAnnexBAdaptor {
             firstSenderHostTime = payload.firstFrameTimestamp
             firstReceiverHostTime = CMClockGetTime(CMClockGetHostTimeClock())
             
-            logDiff(senderHostTime: payload.firstFrameTimestamp, senderPTS: payload.presentationTimestamp, receiverHostTime: CMTimeGetSeconds(CMClockGetTime(CMClockGetHostTimeClock())), receiverPTS: CMTimeGetSeconds(CMClockGetTime(CMClockGetHostTimeClock())))
+            logDiff(
+              receiverHostTime: CMTimeGetSeconds(CMClockGetTime(CMClockGetHostTimeClock())),
+              receiverPTS: CMTimeGetSeconds(CMClockGetTime(CMClockGetHostTimeClock()))
+            )
             Self.logger.debug("Decoder synchronized clocks. First Sender TS: \(payload.firstFrameTimestamp)")
             
           // 첫 프레임은 계산된 HostTime (지금)을 반환
@@ -176,9 +174,10 @@ public final class VideoDecoderAnnexBAdaptor {
         // targetHostTime = (Receiver의 첫 시간) + (미디어 시간 경과)
         let targetHostTime = CMTimeAdd(firstReceiverHostTime!, mediaDurationSeconds.cmTime)
       
-        logDiff(senderHostTime: payload.firstFrameTimestamp, senderPTS: payload.presentationTimestamp, receiverHostTime: CMTimeGetSeconds(CMClockGetTime(CMClockGetHostTimeClock())), receiverPTS: CMTimeGetSeconds(targetHostTime))
-        
         let now = CMClockGetTime(CMClockGetHostTimeClock())
+      
+        logDiff(receiverHostTime: CMTimeGetSeconds(now), receiverPTS: CMTimeGetSeconds(targetHostTime))
+        
         return min(targetHostTime, now + maxFuture)
     }
 }

--- a/Sources/Transcoding/VideoDecoderAnnexBAdaptor.swift
+++ b/Sources/Transcoding/VideoDecoderAnnexBAdaptor.swift
@@ -15,10 +15,12 @@ public final class VideoDecoderAnnexBAdaptor {
 
     public init(
         videoDecoder: VideoDecoder,
-        codec: Codec
+        codec: Codec,
+        maxFuture: CMTime = CMTime(seconds: 0.05, preferredTimescale: 1_000_000_000)
     ) {
         self.videoDecoder = videoDecoder
         self.codec = codec
+        self.maxFuture = maxFuture
     }
 
     // MARK: Public
@@ -54,6 +56,9 @@ public final class VideoDecoderAnnexBAdaptor {
     var vps: Data?
     var sps: Data?
     var pps: Data?
+  
+    /// 변환한 PTS가 미래 시간일 때, 허용 가능한 오차 범위 (기본값 0.05초)
+    let maxFuture: CMTime
 
     func decodeH264(_ data: Data, pts: CMTime? = nil) {
         for nalu in data.split(separator: H264NALU.startCode).map({ H264NALU(data: Data($0)) }) {
@@ -108,7 +113,7 @@ public final class VideoDecoderAnnexBAdaptor {
         let timingInfo = CMSampleTimingInfo(
             duration: .invalid,
             presentationTimeStamp: pts ?? .invalid,
-            decodeTimeStamp: pts ?? .invalid
+            decodeTimeStamp: .invalid
         )
 
         var data = data
@@ -128,6 +133,24 @@ public final class VideoDecoderAnnexBAdaptor {
             }
         }
     }
+  
+    private func logDiff(senderHostTime: TimeInterval, senderPTS: TimeInterval, receiverHostTime: TimeInterval, receiverPTS: TimeInterval) {
+        let hostTimeDiff = receiverHostTime - senderHostTime
+        let ptsDiff = receiverPTS - senderPTS
+        let latency = receiverHostTime - receiverPTS
+        
+        Self.logger.debug(
+          """
+          [FrameLog] SenderHostTime: \(String(format: "%.3f", senderHostTime), privacy: .public), \n\
+          SenderPTS: \(String(format: "%.3f", senderPTS), privacy: .public), \n\
+          ReceiverHostTime (Mine): \(String(format: "%.3f", receiverHostTime), privacy: .public), \n\
+          ReceiverPTS (Mine): \(String(format: "%.3f", receiverPTS), privacy: .public), \n\
+          HostTimeDiff: \(String(format: "%.3f", hostTimeDiff), privacy: .public)s, \n\
+          PTSDiff: \(String(format: "%.3f", ptsDiff), privacy: .public)s, \n\
+          Latency: \(String(format: "%.3f", latency), privacy: .public)s,
+          """
+        )
+    }
 
     /// Payload의 상대 시간을 Receiver의 Host Time으로 변환한다.
     private func convertPayloadToReceiverHostTime(_ payload: AnnexBPayload) -> CMTime {
@@ -137,8 +160,10 @@ public final class VideoDecoderAnnexBAdaptor {
             firstSenderHostTime = payload.firstFrameTimestamp
             firstReceiverHostTime = CMClockGetTime(CMClockGetHostTimeClock())
             
+            logDiff(senderHostTime: payload.firstFrameTimestamp, senderPTS: payload.presentationTimestamp, receiverHostTime: CMTimeGetSeconds(CMClockGetTime(CMClockGetHostTimeClock())), receiverPTS: CMTimeGetSeconds(CMClockGetTime(CMClockGetHostTimeClock())))
             Self.logger.debug("Decoder synchronized clocks. First Sender TS: \(payload.firstFrameTimestamp)")
-            // 첫 프레임은 계산된 HostTime (지금)을 반환
+            
+          // 첫 프레임은 계산된 HostTime (지금)을 반환
             return firstReceiverHostTime!
         }
         
@@ -150,8 +175,11 @@ public final class VideoDecoderAnnexBAdaptor {
         // (Receiver의 HostTime 기준 PTS 계산)
         // targetHostTime = (Receiver의 첫 시간) + (미디어 시간 경과)
         let targetHostTime = CMTimeAdd(firstReceiverHostTime!, mediaDurationSeconds.cmTime)
+      
+        logDiff(senderHostTime: payload.firstFrameTimestamp, senderPTS: payload.presentationTimestamp, receiverHostTime: CMTimeGetSeconds(CMClockGetTime(CMClockGetHostTimeClock())), receiverPTS: CMTimeGetSeconds(targetHostTime))
         
-        return targetHostTime
+        let now = CMClockGetTime(CMClockGetHostTimeClock())
+        return min(targetHostTime, now + maxFuture)
     }
 }
 


### PR DESCRIPTION
- 디코딩 기기에서,
- AnnexB 데이터와 함께 전달되는 시간 데이터를, 현재 기기의 Host Time에 기준한 시각으로 변환할 때,
- 가끔 미래 시간이 반환되는 경우가 있음

&nbsp;

- 아마도 네트워크 혼잡이나 디코딩 파이프라인 지연 등이 원인 같음
- 자세한 문제는 더 분석해봐야할 것 같으나 우선 현재 시간 기준으로 오차(maxFuture) 범위를 넘어서는 더 미래인 경우 클램핑하도록 수정함
- 계속 추적 필요